### PR TITLE
 cr5: Add code for new view and buffer

### DIFF
--- a/asn3/jEdit/org/gjt/sp/jedit/actions.xml
+++ b/asn3/jEdit/org/gjt/sp/jedit/actions.xml
@@ -533,6 +533,12 @@
 	</CODE>
 </ACTION>
 
+<ACTION NAME="new-view-and-buffer">
+	<CODE>
+		jEdit.newViewAndBuffer(view,buffer);
+	</CODE>
+</ACTION>
+
 <ACTION NAME="next-bracket">
 	<CODE>
 		textArea.goToNextBracket(false);

--- a/asn3/jEdit/org/gjt/sp/jedit/jEdit.java
+++ b/asn3/jEdit/org/gjt/sp/jedit/jEdit.java
@@ -24,6 +24,8 @@ package org.gjt.sp.jedit;
 //{{{ Imports
 import bsh.UtilEvalError;
 import javax.swing.*;
+import javax.swing.text.Segment;
+
 import java.awt.event.KeyEvent;
 import java.awt.*;
 import java.io.*;
@@ -2153,6 +2155,23 @@ public class jEdit
 	{
 		return newView(view,buffer,false);
 	} //}}}
+	
+	public static View newViewAndBuffer(View view, Buffer buffer)
+	{
+		Segment seg;
+		View newView;
+		Buffer newBuffer;
+		
+		seg = new Segment();
+		newView = newView(view, buffer);
+		newBuffer = newFile(newView);
+		
+		buffer.getText(0, buffer.getLength(), seg);
+		
+		newBuffer.insert(0, seg);
+		
+		return newView;
+	}
 
 	//{{{ newView() method
 	/**

--- a/asn3/jEdit/org/gjt/sp/jedit/jedit_gui.props
+++ b/asn3/jEdit/org/gjt/sp/jedit/jedit_gui.props
@@ -471,6 +471,7 @@ next-fold.label=Go to $Next Fold
 #{{{ View menu
 view=new-view \
      new-plain-view \
+     new-view-and-buffer \
      close-view \
      - \
      prev-buffer \
@@ -486,6 +487,7 @@ view=new-view \
 view.label=$View
 new-view.label=New $View
 new-plain-view.label=Ne$w Plain View
+new-view-and-buffer.label=New View And B$uffer
 close-view.label=$Close View
 prev-buffer.label=Go to $Previous Buffer
 next-buffer.label=Go to $Next Buffer
@@ -883,7 +885,7 @@ about.text=jEdit is brought to you by\n\
 	Ben Williams\n\
 	Bertalan Fodor\n\
 	Bill McMilleon\n\
-	Björn "Vampire" Kautler\n\
+	Bjï¿½rn "Vampire" Kautler\n\
 	Brad Mace\n\
 	Brant Langer Gurganus\n\
 	Brett Smith\n\


### PR DESCRIPTION
There's a new option in the menu that will open a new view, with a new buffer, but it keeps the same data from the old view that it used (as opposed to new view, new buffer, and blank)